### PR TITLE
Ensure main look fits viewport and selectors stay clickable

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,12 +4,53 @@
 <meta charset="UTF-8">
 <title>Buy The Look</title>
 <style>
-body { margin:0; display:flex; flex-direction:column; height:100vh; }
-#asset-selector, #dress-selector { display:flex; overflow-x:auto; padding:10px; gap:10px; background:#f2f2f2; }
-#asset-selector img, #dress-selector img { height:80px; cursor:pointer; border:2px solid transparent; }
-#asset-selector img.selected, #dress-selector img.selected { border-color:#007bff; }
-#main-display { flex:1; display:flex; align-items:center; justify-content:center; background:#fff; }
-#main-display img { max-width:100%; max-height:100%; }
+html, body {
+  margin: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  display: flex;
+  flex-direction: column;
+}
+
+#asset-selector, #dress-selector {
+  display: flex;
+  overflow-x: auto;
+  padding: 10px;
+  gap: 10px;
+  background: #f2f2f2;
+  position: relative;
+  z-index: 2;
+}
+
+#asset-selector img, #dress-selector img {
+  height: 80px;
+  cursor: pointer;
+  border: 2px solid transparent;
+}
+
+#asset-selector img.selected, #dress-selector img.selected {
+  border-color: #007bff;
+}
+
+#main-display {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  position: relative;
+  z-index: 1;
+}
+
+#main-display img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  pointer-events: none;
+}
 </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Resize main look image to fill the viewport without scrollbars
- Raise asset and dress selectors above the main image for reliable selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c54b5e1f6883259e78acc17ce527cc