### PR TITLE
fix: ensure desktop image fits screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,8 +46,8 @@ body {
 }
 
 #main-display img {
-  width: 100%;
-  height: 100%;
+  max-width: 100%;
+  max-height: 100%;
   object-fit: contain;
   pointer-events: none;
 }


### PR DESCRIPTION
## Summary
- prevent main image from overflowing viewport on desktop

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c54de4ebbc83258fbeb2dac703a3f4