### PR TITLE
Fix main image overflowing viewport in Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,7 @@ body {
   background: #fff;
   position: relative;
   z-index: 1;
+  min-height: 0;
 }
 
 #main-display img {


### PR DESCRIPTION
## Summary
- ensure `#main-display` can shrink so selected image fits within viewport and filters stay accessible

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open '/workspace/BuyTheLook/package.json')

------
https://chatgpt.com/codex/tasks/task_e_68c55923b19483259b10bad0088462cd