### PR TITLE
Ensure main image fits desktop screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,17 +28,20 @@ body {
 }
 #main-display {
   flex: 1;
-  overflow-y: auto;
+  overflow: auto;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
   align-content: flex-start;
+  align-items: center;
   gap: 10px;
   padding: 10px;
   background: #fff;
 }
 #main-display img {
   max-width: 100%;
+  max-height: calc(100vh - 120px);
+  width: auto;
   height: auto;
   object-fit: contain;
 }


### PR DESCRIPTION
## Summary
- prevent desktop image from exceeding viewport height
- allow space for filter controls on top

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5685ce2fc8325930795d5d46e7cba