### PR TITLE
Add dropdown filters and enlarge filter images

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,14 +27,20 @@ body {
   font-family: sans-serif;
   font-size: 14px;
 }
+.filter summary {
+  cursor: pointer;
+}
 .filter .options {
-  display: flex;
+  display: none;
   gap: 5px;
   margin-top: 5px;
 }
+.filter[open] .options {
+  display: flex;
+}
 .filter .options img {
-  width: 40px;
-  height: 40px;
+  width: 120px;
+  height: 120px;
   object-fit: cover;
   border: 2px solid transparent;
   cursor: pointer;
@@ -58,7 +64,7 @@ body {
 }
 #main-display img {
   max-width: 100%;
-  max-height: calc(100vh - 120px);
+  max-height: calc(100vh - 220px);
   width: auto;
   height: auto;
   object-fit: contain;
@@ -215,13 +221,13 @@ function init() {
   });
 
   Object.keys(productsByType).forEach(type => {
-    const wrapper = document.createElement('div');
+    const wrapper = document.createElement('details');
     wrapper.className = 'filter';
-    const title = document.createElement('span');
-    title.textContent = type;
+    const summary = document.createElement('summary');
+    summary.textContent = type;
     const options = document.createElement('div');
     options.className = 'options';
-    wrapper.appendChild(title);
+    wrapper.appendChild(summary);
     wrapper.appendChild(options);
     filterContainer.appendChild(wrapper);
     filters[type] = {};


### PR DESCRIPTION
## Summary
- Replace filter sections with `<details>` dropdowns for cleaner UI
- Enlarge filter option images to improve visibility
- Adjust main image height to accommodate larger filter area

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c56c3bb6708325bbcadf6cea0d8dab