### PR TITLE
Use dedicated product images for filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -103,10 +103,10 @@ function parseFileName(file) {
 function buildProductImageMap(images) {
   const map = {};
   images.forEach(img => {
-    img.products.forEach(p => {
-      if (!map[p.type]) map[p.type] = {};
-      if (!map[p.type][p.brand]) map[p.type][p.brand] = img.file;
-    });
+    if (img.products.length !== 1) return;
+    const p = img.products[0];
+    if (!map[p.type]) map[p.type] = {};
+    map[p.type][p.brand] = img.file;
   });
   return map;
 }


### PR DESCRIPTION
## Summary
- show filter options only when a product has a standalone image
- prevent multi-product images from representing products in filters

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c572a377f08325908b6877d2dc0f36