### PR TITLE
feat: display filters vertically with overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,15 +10,20 @@ html, body {
   overflow: hidden;
 }
 body {
-  display: flex;
-  flex-direction: column;
+  display: block;
 }
 #filters {
+  position: fixed;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 150px;
   display: flex;
+  flex-direction: column;
   gap: 10px;
   padding: 10px;
   background: #f2f2f2;
-  overflow-x: auto;
+  overflow-y: auto;
 }
 .filter {
   display: flex;
@@ -33,10 +38,19 @@ body {
 .filter .options {
   display: none;
   gap: 5px;
-  margin-top: 5px;
 }
 .filter[open] .options {
   display: flex;
+  flex-direction: column;
+  position: fixed;
+  left: 150px;
+  top: 0;
+  bottom: 0;
+  width: 150px;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 10px;
+  overflow-y: auto;
+  z-index: 1000;
 }
 .filter .options img {
   width: 120px;
@@ -44,6 +58,7 @@ body {
   object-fit: cover;
   border: 2px solid transparent;
   cursor: pointer;
+  margin-bottom: 5px;
 }
 .filter .options img.selected {
   border-color: #007BFF;
@@ -53,7 +68,8 @@ body {
   pointer-events: none;
 }
 #main-display {
-  flex: 1;
+  margin-left: 150px;
+  height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
   padding: 10px;


### PR DESCRIPTION
## Summary
- Convert filters into a fixed vertical sidebar
- Show filter options as an overlaid vertical list on the main display

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5739151488325a97411ae3bef4d34