### PR TITLE
Display filter options as vertical overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,13 +13,15 @@ body {
   display: flex;
   flex-direction: column;
 }
-#filters {
-  display: flex;
-  gap: 10px;
-  padding: 10px;
-  background: #f2f2f2;
-  overflow-x: auto;
-}
+  #filters {
+    display: flex;
+    gap: 10px;
+    padding: 10px;
+    background: #f2f2f2;
+    overflow-x: auto;
+    position: relative;
+    z-index: 2;
+  }
 .filter {
   display: flex;
   flex-direction: column;
@@ -30,14 +32,23 @@ body {
 .filter summary {
   cursor: pointer;
 }
-.filter .options {
-  display: none;
-  gap: 5px;
-  margin-top: 5px;
-}
-.filter[open] .options {
-  display: flex;
-}
+  .filter .options {
+    display: none;
+    gap: 5px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background: #fff;
+    flex-direction: column;
+    overflow-y: auto;
+    padding: 10px;
+    z-index: 1;
+  }
+  .filter[open] .options {
+    display: flex;
+  }
 .filter .options img {
   width: 120px;
   height: 120px;

--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@ body {
       background: #f2f2f2;
       overflow-x: auto;
       position: relative;
-      z-index: 5;
+      z-index: 1000;
     }
   .filter {
     position: relative;
@@ -45,7 +45,7 @@ body {
     overflow-y: auto;
     padding: 10px;
     width: 150px;
-    z-index: 999;
+    z-index: 1001;
   }
   .filter[open] .options {
     display: flex;
@@ -70,6 +70,8 @@ body {
   overflow-x: hidden;
   padding: 10px;
   background: #fff;
+  position: relative;
+  z-index: 1;
 }
 #collage {
   column-count: 3;

--- a/index.html
+++ b/index.html
@@ -18,9 +18,9 @@ body {
       gap: 10px;
       padding: 10px;
       background: #f2f2f2;
-      overflow-x: auto;
       position: relative;
       z-index: 1000;
+      overflow: visible;
     }
   .filter {
     position: relative;
@@ -30,9 +30,12 @@ body {
     font-family: sans-serif;
     font-size: 14px;
   }
-.filter summary {
-  cursor: pointer;
-}
+  .filter button {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+  }
   .filter .options {
     display: none;
     gap: 5px;
@@ -47,7 +50,7 @@ body {
     width: 150px;
     z-index: 1001;
   }
-  .filter[open] .options {
+  .filter.open .options {
     display: flex;
   }
 .filter .options img {
@@ -182,13 +185,19 @@ function init() {
   const filterContainer = document.getElementById('filters');
 
   Object.keys(productsByType).forEach(type => {
-    const wrapper = document.createElement('details');
+    const wrapper = document.createElement('div');
     wrapper.className = 'filter';
-    const summary = document.createElement('summary');
-    summary.textContent = type;
+    const button = document.createElement('button');
+    button.textContent = type;
     const options = document.createElement('div');
     options.className = 'options';
-    wrapper.appendChild(summary);
+    button.addEventListener('click', () => {
+      document.querySelectorAll('#filters .filter').forEach(f => {
+        if (f !== wrapper) f.classList.remove('open');
+      });
+      wrapper.classList.toggle('open');
+    });
+    wrapper.appendChild(button);
     wrapper.appendChild(options);
     filterContainer.appendChild(wrapper);
     filters[type] = {};
@@ -209,6 +218,7 @@ function init() {
         updateFilterImages(filters, images, selected);
         const filteredImages = filterImages(images, selected);
         renderImages(filteredImages);
+        wrapper.classList.remove('open');
       });
       options.appendChild(imgEl);
       filters[type][brand] = imgEl;

--- a/index.html
+++ b/index.html
@@ -22,28 +22,29 @@ body {
     position: relative;
     z-index: 2;
   }
-.filter {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  font-family: sans-serif;
-  font-size: 14px;
-}
+  .filter {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    font-family: sans-serif;
+    font-size: 14px;
+  }
 .filter summary {
   cursor: pointer;
 }
   .filter .options {
     display: none;
     gap: 5px;
-    position: fixed;
-    top: 0;
+    position: absolute;
+    top: 100%;
     left: 0;
-    right: 0;
-    bottom: 0;
     background: #fff;
     flex-direction: column;
+    max-height: calc(100vh - 100px);
     overflow-y: auto;
     padding: 10px;
+    width: 150px;
     z-index: 1;
   }
   .filter[open] .options {

--- a/index.html
+++ b/index.html
@@ -14,14 +14,14 @@ body {
   flex-direction: column;
 }
   #filters {
-    display: flex;
-    gap: 10px;
-    padding: 10px;
-    background: #f2f2f2;
-    overflow-x: auto;
-    position: relative;
-    z-index: 2;
-  }
+      display: flex;
+      gap: 10px;
+      padding: 10px;
+      background: #f2f2f2;
+      overflow-x: auto;
+      position: relative;
+      z-index: 5;
+    }
   .filter {
     position: relative;
     display: flex;
@@ -45,7 +45,7 @@ body {
     overflow-y: auto;
     padding: 10px;
     width: 150px;
-    z-index: 1;
+    z-index: 999;
   }
   .filter[open] .options {
     display: flex;


### PR DESCRIPTION
## Summary
- Ensure filter bar stays above overlay
- Show product options in a vertical overlay covering the main section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5756406a48325b6460dc724463766