### PR TITLE
Add MoniTTa logo and dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,12 +12,16 @@ html, body {
 body {
   display: flex;
   flex-direction: column;
+  position: relative;
+  background: #2d2a24;
+  color: #fff;
 }
   #filters {
       display: flex;
       gap: 10px;
       padding: 10px;
-      background: #f2f2f2;
+      padding-right: 170px;
+      background: #403d37;
       position: relative;
       z-index: 1000;
       overflow: visible;
@@ -54,6 +58,7 @@ body {
       text-align: center;
       white-space: pre-line;
       font-size: 12px;
+      color: #fff;
     }
     .filter button.selected .preview {
       display: block;
@@ -74,7 +79,7 @@ body {
     position: absolute;
     top: 100%;
     left: 0;
-    background: #fff;
+    background: #403d37;
     flex-direction: column;
     max-height: calc(100vh - 100px);
     overflow-y: auto;
@@ -93,7 +98,7 @@ body {
   cursor: pointer;
 }
 .filter .options img.selected {
-  border-color: #007BFF;
+  border-color: #fff;
 }
 .filter .options img.disabled {
   opacity: 0.3;
@@ -104,7 +109,7 @@ body {
   overflow-y: auto;
   overflow-x: hidden;
   padding: 10px;
-  background: #fff;
+  background: #2d2a24;
   position: relative;
   z-index: 1;
 }
@@ -118,9 +123,19 @@ body {
   margin-bottom: 10px;
   display: block;
 }
+#logo {
+  position: absolute;
+  top: 10px;
+  right: 10px;
+  width: 150px;
+  height: auto;
+  z-index: 1002;
+  pointer-events: none;
+}
 </style>
 </head>
 <body>
+<img id="logo" src="MoniTTa.png" alt="MoniTTa logo">
 <div id="filters"></div>
 <div id="main-display">
   <div id="collage"></div>


### PR DESCRIPTION
## Summary
- Add MoniTTa logo to the page header and reserve space for it
- Switch site styling to dark greys matching the logo

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c583723b688325a346898ec6970418