### PR TITLE
Hide zero product size in overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -255,7 +255,10 @@ function renderImages(images) {
     const info = document.createElement('div');
     info.className = 'product-info';
     info.innerHTML = img.products
-      .map(p => `${p.brand} ${p.name} ${p.size}`)
+      .map(p => {
+        const sizePart = p.size && p.size !== '0' ? ` ${p.size}` : '';
+        return `${p.brand} ${p.name}${sizePart}`;
+      })
       .join('<br>');
     container.appendChild(info);
 


### PR DESCRIPTION
## Summary
- Avoid showing size "0" in product info overlays by skipping the size

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c589cbfb908325a5a1f4a905420380