### PR TITLE
Hide duplicate brand names on product overlays

### DIFF
--- a/index.html
+++ b/index.html
@@ -257,7 +257,8 @@ function renderImages(images) {
     info.innerHTML = img.products
       .map(p => {
         const sizePart = p.size && p.size !== '0' ? ` ${p.size}` : '';
-        return `${p.brand} ${p.name}${sizePart}`;
+        const displayName = p.name === p.brand ? p.name : `${p.brand} ${p.name}`;
+        return `${displayName}${sizePart}`;
       })
       .join('<br>');
     container.appendChild(info);


### PR DESCRIPTION
## Summary
- Avoid repeating product brand on image overlays when brand and product name are identical

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c58b09f0ec8325aa142654a39fb907