### PR TITLE
Display product type and icon in collage overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -136,7 +136,7 @@ body {
   background: rgba(0, 0, 0, 0.7);
   color: #fff;
   padding: 4px 6px;
-  font-weight: bold;
+  font-weight: normal;
   font-family: sans-serif;
   font-size: 14px;
   line-height: 1.2;
@@ -253,7 +253,7 @@ function updateFilterImages(filters, allImages, selected) {
     });
   }
 
-function renderImages(images) {
+function renderImages(images, productMap) {
   const collage = document.getElementById('collage');
   collage.innerHTML = '';
   images.forEach(img => {
@@ -270,7 +270,10 @@ function renderImages(images) {
       .map(p => {
         const sizePart = p.size && p.size !== '0' ? ` ${p.size}` : '';
         const displayName = p.name === p.brand ? p.name : `${p.brand} ${p.name}`;
-        return `${displayName}${sizePart}`;
+        const typeImage = productMap[p.type] && productMap[p.type][p.brand]
+          ? `<img src="${productMap[p.type][p.brand]}" style="height:1em;vertical-align:middle;margin-right:4px;">`
+          : '';
+        return `${typeImage}${p.type} ${displayName}${sizePart}`;
       })
       .join('<br>');
     container.appendChild(info);
@@ -347,8 +350,8 @@ async function init() {
           }
           updateFilterImages(filters, images, selected);
           updateFilterButtons(buttons, selected, filters);
-          const filteredImages = filterImages(images, selected);
-          renderImages(filteredImages);
+            const filteredImages = filterImages(images, selected);
+            renderImages(filteredImages, productsByType);
           wrapper.classList.remove('open');
         });
         options.appendChild(imgEl);
@@ -357,8 +360,8 @@ async function init() {
     });
     updateFilterImages(filters, images, selected);
     updateFilterButtons(buttons, selected, filters);
-    const filteredImages = filterImages(images, selected);
-    renderImages(filteredImages);
+      const filteredImages = filterImages(images, selected);
+      renderImages(filteredImages, productsByType);
   } catch (err) {
     console.error('Failed to load product images', err);
   }


### PR DESCRIPTION
## Summary
- Show product type before brand in collage captions
- Use normal font weight for product info overlays
- Prepend primary product image icons when available

## Testing
- `npm test` *(fails: ENOENT could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5a896eb588325923cf93baeb43e43