### PR TITLE
Lazy load collage images

### DIFF
--- a/index.html
+++ b/index.html
@@ -260,15 +260,29 @@ function updateFilterImages(filters, allImages, selected) {
     });
   }
 
+const mainDisplay = document.getElementById('main-display');
+const lazyObserver = new IntersectionObserver((entries, observer) => {
+  entries.forEach(entry => {
+    if (entry.isIntersecting) {
+      const imgEl = entry.target;
+      imgEl.src = imgEl.dataset.src;
+      imgEl.removeAttribute('data-src');
+      observer.unobserve(imgEl);
+    }
+  });
+}, { root: mainDisplay });
+
 function renderImages(images, productMap) {
   const collage = document.getElementById('collage');
   collage.innerHTML = '';
+  lazyObserver.disconnect();
   images.forEach(img => {
     const container = document.createElement('div');
     container.className = 'collage-item';
 
     const imgEl = document.createElement('img');
-    imgEl.src = img.file;
+    imgEl.setAttribute('data-src', img.file);
+    lazyObserver.observe(imgEl);
     container.appendChild(imgEl);
 
     const info = document.createElement('div');


### PR DESCRIPTION
## Summary
- Only load collage images when visible with IntersectionObserver
- Disconnect observer on re-render and defer setting `src` until image enters view

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5b7c1f1848325840b3f254d501b9a