### PR TITLE
Fix lazy loading of collage images

### DIFF
--- a/index.html
+++ b/index.html
@@ -282,7 +282,6 @@ function renderImages(images, productMap) {
 
     const imgEl = document.createElement('img');
     imgEl.setAttribute('data-src', img.file);
-    lazyObserver.observe(imgEl);
     container.appendChild(imgEl);
 
     const info = document.createElement('div');
@@ -300,6 +299,7 @@ function renderImages(images, productMap) {
     container.appendChild(info);
 
     collage.appendChild(container);
+    lazyObserver.observe(imgEl);
   });
 }
 


### PR DESCRIPTION
## Summary
- ensure lazy loading works by observing images only after they're attached to the DOM

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5bc2c549c832592f1c3b6236f448f